### PR TITLE
Query Parameters

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,7 +1,5 @@
 package firego
 
-const authParam = "auth"
-
 // Auth sets the custom Firebase token used to authenticate to Firebase
 func (fb *Firebase) Auth(token string) {
 	fb.params.Set(authParam, token)

--- a/auth.go
+++ b/auth.go
@@ -1,11 +1,13 @@
 package firego
 
+const authParam = "auth"
+
 // Auth sets the custom Firebase token used to authenticate to Firebase
 func (fb *Firebase) Auth(token string) {
-	fb.auth = token
+	fb.params.Set(authParam, token)
 }
 
 // Unauth removes the current token being used to authenticate to Firebase
 func (fb *Firebase) Unauth() {
-	fb.auth = ""
+	fb.params.Del(authParam)
 }

--- a/firebase.go
+++ b/firebase.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+// query parameter constants
+const (
+	authParam   = "auth"
+	formatParam = "format"
+	formatVal   = "export"
+)
+
 // Firebase represents a location in the cloud
 type Firebase struct {
 	url          string
@@ -66,6 +73,21 @@ func (fb *Firebase) Child(child string) *Firebase {
 		params:       fb.params,
 		client:       fb.client,
 		stopWatching: make(chan struct{}),
+	}
+}
+
+// IncludePriority determines whether or not to ask Firebase
+// for the values priority. By default, the priority is not returned
+//
+//		# Include Priority
+//		ref.IncludePriority(true)
+//		# Exclude Priority
+//		ref.IncludePriority(false)
+func (fb *Firebase) IncludePriority(v bool) {
+	if v {
+		fb.params.Set(formatParam, formatVal)
+	} else {
+		fb.params.Del(formatParam)
 	}
 }
 

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -43,3 +43,43 @@ func TestChild(t *testing.T) {
 		t.Fatalf("url not set corrected. Expected: %s\nActual: %s", expected, child.url)
 	}
 }
+
+func TestIncludePriority(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		priority bool
+	}{
+		{
+			true,
+		},
+		{
+			false,
+		},
+	}
+
+	for _, tt := range testCases {
+		var (
+			server = newTestServer("")
+			fb     = New(server.URL)
+		)
+		defer server.Close()
+		fb.IncludePriority(tt.priority)
+		fb.Value("")
+		if expected, actual := 1, len(server.receivedReqs); expected != actual {
+			t.Fatalf("Expected: %d\nActual: %d", expected, actual)
+		}
+
+		req := server.receivedReqs[0]
+		expected, actual := formatParam+"="+formatVal, req.URL.Query().Encode()
+
+		if tt.priority {
+			if expected != actual {
+				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
+			}
+		} else {
+			if expected == actual {
+				t.Fatalf(`Expected: ""\nActual: %s`, actual)
+			}
+		}
+	}
+}

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -44,6 +44,46 @@ func TestChild(t *testing.T) {
 	}
 }
 
+func TestShallow(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		shallow bool
+	}{
+		{
+			true,
+		},
+		{
+			false,
+		},
+	}
+
+	for _, tt := range testCases {
+		var (
+			server = newTestServer("")
+			fb     = New(server.URL)
+		)
+		defer server.Close()
+		fb.Shallow(tt.shallow)
+		fb.Value("")
+		if expected, actual := 1, len(server.receivedReqs); expected != actual {
+			t.Fatalf("Expected: %d\nActual: %d", expected, actual)
+		}
+
+		req := server.receivedReqs[0]
+		expected, actual := shallowParam+"=true", req.URL.Query().Encode()
+
+		if tt.shallow {
+			if expected != actual {
+				t.Fatalf("Expected: %s\nActual: %s", expected, actual)
+			}
+		} else {
+			if expected == actual {
+				t.Fatalf(`Expected: ""\nActual: %s`, actual)
+			}
+		}
+	}
+}
+
 func TestIncludePriority(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {


### PR DESCRIPTION
This is an initial rev for #7 . Adding functionality to add include the following query parameters on every request:
- [format](https://www.firebase.com/docs/rest/api/#section-param-format)
- [shallow](https://www.firebase.com/docs/rest/api/#section-param-shallow)

On a side note - I'm not too sure if it's worth implementing the [silent print](https://www.firebase.com/docs/rest/api/#section-param-print) query parameter or if we should just default every request to use `print=silent` since `Update`, `Push`, and `Set` don't return the object response.
