### PR TITLE
Smarter Timeout

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -45,19 +45,14 @@ func sanitizeURL(url string) string {
 // New creates a new Firebase reference
 func New(url string) *Firebase {
 
-	// The article below explains how Amazon's ELB's to not always send the "close_notify packet"
-	// when using TLS.  By default the golang http client attempts to reuse connectons.  This
-	// caused an issue because, the server closed the connection, we never received the close_notify
-	// thus, golang http client tried to reuse a closed connection.  This issue does not happen all
-	// the time, but it did happen once in every 5 requests that are fired off one right after the
-	// other.  Note, the article below is for AWS, but seems to have the same issue with Firebase.
-	// The fix for me, is to disable the KeepAlives with really causes golang not to reause the
-	// connection.
-	// https://code.google.com/p/go/issues/detail?id=3514
-	tr := &http.Transport{
-		DisableKeepAlives: true,
+	var tr *http.Transport
+	tr = &http.Transport{
+		DisableKeepAlives: true, // https://code.google.com/p/go/issues/detail?id=3514
 		Dial: func(network, address string) (net.Conn, error) {
-			return net.DialTimeout(network, address, TimeoutDuration)
+			start := time.Now()
+			c, err := net.DialTimeout(network, address, TimeoutDuration)
+			tr.ResponseHeaderTimeout = TimeoutDuration - time.Since(start)
+			return c, err
 		},
 	}
 

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -49,15 +50,42 @@ func TestChild(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s/%s", parent.url, childNode), child.url)
 }
 
-func TestTimeoutDuration(t *testing.T) {
+type timeout interface {
+	Timeout() bool
+}
+
+func TestTimeoutDuration_Headers(t *testing.T) {
+	defer func(dur time.Duration) { TimeoutDuration = dur }(TimeoutDuration)
 	TimeoutDuration = time.Millisecond
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		time.Sleep(2 * TimeoutDuration)
 	}))
+	defer server.Close()
 
 	fb := New(server.URL)
 	err := fb.Value("")
 	assert.NotNil(t, err)
+	e1 := err.(*url.Error).Err.(timeout)
+	assert.True(t, e1.Timeout())
+
+	// ResponseHeaderTimeout should be TimeoutDuration less the time it took to dial, and should be positive
+	assert.True(t, fb.client.Transport.(*http.Transport).ResponseHeaderTimeout < TimeoutDuration)
+	assert.True(t, fb.client.Transport.(*http.Transport).ResponseHeaderTimeout > 0)
+}
+
+func TestTimeoutDuration_Dial(t *testing.T) {
+	defer func(dur time.Duration) { TimeoutDuration = dur }(TimeoutDuration)
+	TimeoutDuration = time.Microsecond
+
+	fb := New("http://dialtimeouterr.or/")
+	err := fb.Value("")
+	assert.NotNil(t, err)
+	e1 := err.(*url.Error).Err.(timeout)
+	assert.True(t, e1.Timeout())
+
+	// ResponseHeaderTimeout should be negative since the total duration was consumed when dialing
+	assert.True(t, fb.client.Transport.(*http.Transport).ResponseHeaderTimeout < 0)
 }
 
 func TestShallow(t *testing.T) {


### PR DESCRIPTION
changing the timeout functionality so that the request times out if it is able to establish a connection but does not get headers down in time.
