### PR TITLE
Type ErrTimeout

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -143,6 +143,10 @@ func (fb *Firebase) doRequest(method string, body []byte) ([]byte, error) {
 		if e1.Timeout() {
 			return nil, ErrTimeout{err}
 		}
+	case net.Error:
+		if err.Timeout() {
+			return nil, ErrTimeout{err}
+		}
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
add type `ErrTimeout` to indicate that the `TimeoutDuration` was exceeded while talking to Firebase. This saves the implementer a bit of typeassertion.
