### PR TITLE
Event errors

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -94,6 +94,9 @@ func ExampleFirebase_Watch() {
 		log.Printf("Type: %s\n", event.Type)
 		log.Printf("Type: %s\n", event.Path)
 		log.Printf("Type: %v\n", event.Data)
+		if event.Type == firego.EventTypeError {
+			log.Print("Error occurred, loop ending")
+		}
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -92,8 +92,8 @@ func ExampleFirebase_Watch() {
 	for event := range notifications {
 		log.Println("Event Received")
 		log.Printf("Type: %s\n", event.Type)
-		log.Printf("Type: %s\n", event.Path)
-		log.Printf("Type: %v\n", event.Data)
+		log.Printf("Path: %s\n", event.Path)
+		log.Printf("Data: %v\n", event.Data)
 		if event.Type == firego.EventTypeError {
 			log.Print("Error occurred, loop ending")
 		}

--- a/watch.go
+++ b/watch.go
@@ -60,7 +60,7 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 	go func() {
 		// build scanner for response body
 		scanner := bufio.NewReader(resp.Body)
-		var scanResult error
+		var scanErr error
 
 		// monitor the stopWatching channel
 		// if we're told to stop, close the response Body
@@ -69,7 +69,7 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 			resp.Body.Close()
 		}()
 	scanning:
-		for scanResult == nil {
+		for scanErr == nil {
 			// split event string
 			// 		event: put
 			// 		data: {"path":"/","data":{"foo":"bar"}}
@@ -83,8 +83,8 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 			// we need bufio#ReadLine()
 			// 1. step: scan for the 'event:' part. ReadLine() oes not return the \n
 			// so we have to add it to our result buffer.
-			evt, isPrefix, scanResult = scanner.ReadLine()
-			if scanResult != nil {
+			evt, isPrefix, scanErr = scanner.ReadLine()
+			if scanErr != nil {
 				break scanning
 			}
 			result = append(result, evt...)
@@ -94,8 +94,8 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 			// part, but the value can be very large. If we exceed a certain length
 			// isPrefix will be true until all data is read.
 			for {
-				dat, isPrefix, scanResult = scanner.ReadLine()
-				if scanResult != nil {
+				dat, isPrefix, scanErr = scanner.ReadLine()
+				if scanErr != nil {
 					break scanning
 				}
 				result = append(result, dat...)
@@ -105,8 +105,8 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 			}
 			// Again we add the \n
 			result = append(result, '\n')
-			_, _, scanResult = scanner.ReadLine()
-			if scanResult != nil {
+			_, _, scanErr = scanner.ReadLine()
+			if scanErr != nil {
 				break scanning
 			}
 

--- a/watch.go
+++ b/watch.go
@@ -131,7 +131,8 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 				// the extra data is in json format
 				var data map[string]interface{}
 				if err := json.Unmarshal([]byte(strings.Replace(parts[1], "data: ", "", 1)), &data); err != nil {
-					log.Fatal(err)
+					scanErr = err
+					break scanning
 				}
 
 				// set the extra fields

--- a/watch_test.go
+++ b/watch_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strings"
 )
 
 const testToken = "test_token"
@@ -72,10 +73,46 @@ func TestWatch(t *testing.T) {
 	assert.Equal(t, data, event.Data.(string), "event data doesn't match")
 }
 
+func TestWatchError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		flusher, ok := w.(http.Flusher)
+
+		if !ok {
+			t.Fatal("Streaming unsupported!")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		flusher.Flush()
+		time.Sleep(500 * time.Millisecond)
+	}))
+
+	var (
+		notifications = make(chan Event)
+		fb            = New(server.URL)
+	)
+	defer server.Close()
+
+	if err := fb.Watch(notifications); err != nil {
+		t.Fatal(err)
+	}
+
+	go server.Close()
+	event, ok := <-notifications
+	require.True(t, ok, "notifications closed")
+	assert.Equal(t, EventTypeError, event.Type, "event type doesn't match")
+	assert.Empty(t, event.Path, "event path is not empty")
+	assert.NotNil(t, event.Data, "event data is nil")
+	assert.Implements(t, new(error), event.Data)
+}
+
 func TestStopWatch(t *testing.T) {
 	t.Parallel()
 	var (
-		eventType, path, data = "put", "foo", setupLargeResult()
+		eventType, path, data = "put", "foo", "foobar"
 		moveOn, stop          = make(chan struct{}), make(chan struct{})
 		notifications         = make(chan Event)
 		server                = newSSEServer(t, eventType, path, data, stop)

--- a/watch_test.go
+++ b/watch_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,7 +86,6 @@ func TestWatchError(t *testing.T) {
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		flusher.Flush()
-		time.Sleep(500 * time.Millisecond)
 	}))
 
 	var (


### PR DESCRIPTION
There is currently no way to detect if an error occurred while trying to watch a particular Firebase reference.

This PR attempts to solve that by returning an Event with the error contained inside.
