### PR TITLE
using mock firebase server for testing

### DIFF
--- a/firebase_test.go
+++ b/firebase_test.go
@@ -13,6 +13,20 @@ import (
 
 const URL = "https://somefirebaseapp.firebaseIO.com"
 
+type TestServer struct {
+	*httptest.Server
+	receivedReqs []*http.Request
+}
+
+func newTestServer(response string) *TestServer {
+	ts := &TestServer{}
+	ts.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ts.receivedReqs = append(ts.receivedReqs, req)
+		fmt.Fprint(w, response)
+	}))
+	return ts
+}
+
 func TestNew(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {

--- a/push_test.go
+++ b/push_test.go
@@ -1,24 +1,27 @@
 package firego
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/zabawaba99/firetest"
 )
 
 func TestPush(t *testing.T) {
 	t.Parallel()
 	var (
-		response = `{"foo":"bar"}`
-		server   = newTestServer(response)
-		fb       = New(server.URL)
+		payload = map[string]interface{}{"foo": "bar"}
+		server  = firetest.New()
 	)
+	server.Start()
 	defer server.Close()
 
-	fb.Push(response)
-	require.Len(t, server.receivedReqs, 1)
+	fb := New(server.URL)
+	childRef, err := fb.Push(payload)
+	assert.NoError(t, err)
 
-	req := server.receivedReqs[0]
-	assert.Equal(t, "POST", req.Method)
+	path := strings.TrimPrefix(childRef.String(), server.URL+"/")
+	v := server.Get(path)
+	assert.Equal(t, payload, v)
 }

--- a/remove_test.go
+++ b/remove_test.go
@@ -4,20 +4,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/zabawaba99/firetest"
 )
 
 func TestRemove(t *testing.T) {
 	t.Parallel()
-	var (
-		server = newTestServer("")
-		fb     = New(server.URL)
-	)
+	server := firetest.New()
+	server.Start()
 	defer server.Close()
 
-	fb.Remove()
-	require.Len(t, server.receivedReqs, 1)
+	server.Set("", true)
 
-	req := server.receivedReqs[0]
-	assert.Equal(t, "DELETE", req.Method)
+	fb := New(server.URL)
+	err := fb.Remove()
+	assert.NoError(t, err)
+
+	v := server.Get("")
+	assert.Nil(t, v)
 }

--- a/set_test.go
+++ b/set_test.go
@@ -4,21 +4,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/zabawaba99/firetest"
 )
 
 func TestSet(t *testing.T) {
 	t.Parallel()
 	var (
-		response = `{"foo":"bar"}`
-		server   = newTestServer(response)
-		fb       = New(server.URL)
+		payload = map[string]interface{}{"foo": "bar"}
+		server  = firetest.New()
 	)
+	server.Start()
 	defer server.Close()
 
-	fb.Set(response)
-	require.Len(t, server.receivedReqs, 1)
+	fb := New(server.URL)
+	err := fb.Set(payload)
+	assert.NoError(t, err)
 
-	req := server.receivedReqs[0]
-	assert.Equal(t, "PUT", req.Method)
+	v := server.Get("")
+	assert.Equal(t, payload, v)
 }

--- a/update_test.go
+++ b/update_test.go
@@ -4,21 +4,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/zabawaba99/firetest"
 )
 
 func TestUpdate(t *testing.T) {
 	t.Parallel()
 	var (
-		response = `{"foo":"bar"}`
-		server   = newTestServer(response)
-		fb       = New(server.URL)
+		payload = map[string]interface{}{"foo": "bar"}
+		server  = firetest.New()
 	)
+	server.Start()
 	defer server.Close()
 
-	fb.Update(response)
-	require.Len(t, server.receivedReqs, 1)
+	fb := New(server.URL)
+	err := fb.Update(payload)
+	assert.NoError(t, err)
 
-	req := server.receivedReqs[0]
-	assert.Equal(t, "PATCH", req.Method)
+	v := server.Get("")
+	assert.Equal(t, payload, v)
 }

--- a/value_test.go
+++ b/value_test.go
@@ -1,46 +1,27 @@
 package firego
 
 import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/zabawaba99/firetest"
 )
-
-type TestServer struct {
-	*httptest.Server
-	receivedReqs []*http.Request
-}
-
-func newTestServer(response string) *TestServer {
-	ts := &TestServer{}
-	ts.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		ts.receivedReqs = append(ts.receivedReqs, req)
-		fmt.Fprint(w, response)
-	}))
-	return ts
-}
 
 func TestValue(t *testing.T) {
 	t.Parallel()
 	var (
-		response = `{"foo":"bar"}`
-		server   = newTestServer(response)
-		fb       = New(server.URL)
+		response = map[string]interface{}{"foo": "bar"}
+		server   = firetest.New()
 	)
+	server.Start()
 	defer server.Close()
 
+	fb := New(server.URL)
+
+	server.Set("", response)
+
 	var v map[string]interface{}
-	fb.Value(&v)
-	val, ok := v["foo"]
-	assert.True(t, ok)
-	assert.Equal(t, "bar", val)
-
-	require.Len(t, server.receivedReqs, 1)
-
-	req := server.receivedReqs[0]
-	assert.Equal(t, "GET", req.Method)
+	err := fb.Value(&v)
+	assert.NoError(t, err)
+	assert.Equal(t, response, v)
 }

--- a/watch_test.go
+++ b/watch_test.go
@@ -1,85 +1,60 @@
 package firego
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zabawaba99/firetest"
 )
-
-const testToken = "test_token"
 
 func setupLargeResult() string {
 	return "start" + strings.Repeat("0", 64*1024) + "end"
 }
 
-func newSSEServer(t *testing.T, event, path, data string, stop chan struct{}) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		flusher, ok := w.(http.Flusher)
-
-		if !ok {
-			t.Fatal("Streaming unsupported!")
-		}
-		req.ParseForm()
-
-		if req.Form.Get("auth") != testToken {
-			http.Error(w, "Permission denied", http.StatusUnauthorized)
-			flusher.Flush()
-			<-stop
-		}
-
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-
-		// write SSE goodies
-		fmt.Fprintf(w, "event: %s\n", event)
-		fmt.Fprintf(w, "data: {\"path\":\"%s\",\"data\":\"%s\"}\n\n", path, data)
-
-		// Flush the data immediatly instead of buffering it for later.
-		flusher.Flush()
-		<-stop
-	}))
-}
-
 func TestWatch(t *testing.T) {
-	t.Parallel()
-	var (
-		eventType, path, data = "put", "foo", setupLargeResult()
-		notifications, stop   = make(chan Event), make(chan struct{})
-		server                = newSSEServer(t, eventType, path, data, stop)
-		fb                    = New(server.URL)
-	)
-	defer func() {
-		close(stop)
-		server.Close()
-	}()
+	server := firetest.New()
+	server.Start()
+	defer server.Close()
 
-	fb.Auth(testToken)
-	if err := fb.Watch(notifications); err != nil {
-		t.Fatal(err)
+	fb := New(server.URL)
+
+	notifications := make(chan Event)
+	err := fb.Watch(notifications)
+	assert.NoError(t, err)
+
+	l := setupLargeResult()
+	server.Set("/foo", l)
+
+	select {
+	case event, ok := <-notifications:
+		assert.True(t, ok)
+		assert.Equal(t, "put", event.Type)
+		assert.Equal(t, "/", event.Path)
+		assert.Nil(t, event.Data)
+	case <-time.After(250 * time.Millisecond):
+		require.FailNow(t, "did not receive a notification initial notification")
 	}
 
-	event, ok := <-notifications
-	require.True(t, ok, "notifications closed")
-	assert.Equal(t, eventType, event.Type, "event type doesn't match")
-	assert.Equal(t, path, event.Path, "event path doesn't match")
-	assert.Equal(t, data, event.Data.(string), "event data doesn't match")
+	select {
+	case event, ok := <-notifications:
+		assert.True(t, ok)
+		assert.Equal(t, "/foo", event.Path)
+		assert.EqualValues(t, l, event.Data)
+	case <-time.After(250 * time.Millisecond):
+		require.FailNow(t, "did not receive a notification")
+	}
 }
 
 func TestWatchError(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		flusher, ok := w.(http.Flusher)
-
-		if !ok {
-			t.Fatal("Streaming unsupported!")
-		}
+		require.True(t, ok, "streaming unsupported")
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
@@ -109,54 +84,21 @@ func TestWatchError(t *testing.T) {
 
 func TestStopWatch(t *testing.T) {
 	t.Parallel()
-	var (
-		eventType, path, data = "put", "foo", "foobar"
-		moveOn, stop          = make(chan struct{}), make(chan struct{})
-		notifications         = make(chan Event)
-		server                = newSSEServer(t, eventType, path, data, stop)
-		fb                    = New(server.URL)
-	)
-	defer func() {
-		close(stop)
-		server.Close()
+
+	server := firetest.New()
+	server.Start()
+	defer server.Close()
+
+	fb := New(server.URL)
+
+	notifications := make(chan Event)
+	go func() {
+		err := fb.Watch(notifications)
+		assert.NoError(t, err)
 	}()
 
-	fb.Auth(testToken)
-	go func() {
-		if err := fb.Watch(notifications); err != nil {
-			t.Fatal(err)
-		}
-		<-moveOn
-		fb.StopWatching()
-	}()
-	<-notifications
-	moveOn <- struct{}{}
+	<-notifications // get initial notification
+	fb.StopWatching()
 	_, ok := <-notifications
 	assert.False(t, ok, "notifications should be closed")
-}
-
-func TestWatch_Cancel(t *testing.T) {
-	var (
-		eventType, path, data = "cancel", "", ""
-		notifications, stop   = make(chan Event), make(chan struct{})
-		server                = newSSEServer(t, eventType, path, data, stop)
-		fb                    = New(server.URL)
-	)
-
-	defer func() {
-		close(stop)
-		server.Close()
-	}()
-
-	fb.Auth(testToken)
-	if err := fb.Watch(notifications); err != nil {
-		t.Fatal(err)
-	}
-
-	event, ok := <-notifications
-	require.True(t, ok, "notifications closed")
-	assert.Equal(t, eventType, event.Type, "event type doesn't match")
-
-	_, ok = <-notifications
-	require.False(t, ok, "notifications should be closed")
 }


### PR DESCRIPTION
This is the initial move towards using the `firetest` server. I left the `TestServer` struct in there for the meantime until `firetest` supports more query parameters
