### PR TITLE
Copying params manually when creating a child reference

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -88,12 +88,19 @@ func (fb *Firebase) String() string {
 // Child creates a new Firebase reference for the requested
 // child with the same configuration as the parent
 func (fb *Firebase) Child(child string) *Firebase {
-	return &Firebase{
+	c := &Firebase{
 		url:          fb.url + "/" + child,
-		params:       fb.params,
+		params:       _url.Values{},
 		client:       fb.client,
 		stopWatching: make(chan struct{}),
 	}
+
+	// making sure to manually copy the map items into a new
+	// map to avoid modifying the map reference.
+	for k, v := range fb.params {
+		c.params[k] = v
+	}
+	return c
 }
 
 // Shallow limits the depth of the data returned when calling Value.

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -63,6 +63,16 @@ func TestChild(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s/%s", parent.url, childNode), child.url)
 }
 
+func TestChild_Issue26(t *testing.T) {
+	t.Parallel()
+	parent := New(URL)
+	child1 := parent.Child("one")
+	child2 := child1.Child("two")
+
+	child1.Shallow(true)
+	assert.Len(t, child2.params, 0)
+}
+
 func TestTimeoutDuration_Headers(t *testing.T) {
 	defer func(dur time.Duration) { TimeoutDuration = dur }(TimeoutDuration)
 	TimeoutDuration = time.Millisecond


### PR DESCRIPTION
resolves #26
