### PR TITLE
bumping .travis builds to go1.5 and allowing tip to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: go
 
 go:
-  - 1.3
   - 1.4
+  - 1.5
   - tip
+
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
 
 before_install:
   # linting tools


### PR DESCRIPTION
Looks like `tip` is causing some [build issues](https://travis-ci.org/CloudCom/firego/jobs/81980876) when running tests. 

We don't necessarily need it to pass for a build to be successful.
