### PR TITLE
TimeoutDuration redefinition

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -64,17 +64,18 @@ func New(url string) *Firebase {
 	tr = &http.Transport{
 		DisableKeepAlives: true, // https://code.google.com/p/go/issues/detail?id=3514
 		Dial: func(network, address string) (net.Conn, error) {
-			start := time.Now()
-			c, err := net.DialTimeout(network, address, TimeoutDuration)
-			tr.ResponseHeaderTimeout = TimeoutDuration - time.Since(start)
-			return c, err
+			return net.DialTimeout(network, address, TimeoutDuration)
 		},
+		ResponseHeaderTimeout: TimeoutDuration,
 	}
 
 	return &Firebase{
 		url:          sanitizeURL(url),
 		params:       _url.Values{},
-		client:       &http.Client{Transport: tr},
+		client:       &http.Client{
+			Transport: tr,
+			Timeout:   TimeoutDuration,
+		},
 		stopWatching: make(chan struct{}),
 	}
 }

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -72,25 +72,26 @@ func TestTimeoutDuration_Headers(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(2 * TimeoutDuration)
 	}))
+	defer server.Close()
 
 	fb := New(server.URL)
 
 	err := fb.Value("")
 	assert.NotNil(t, err)
 	assert.IsType(t, ErrTimeout{}, err, "%s", err)
-	assert.Equal(t, TimeoutDuration, fb.client.Timeout)
+	assert.Equal(t, TimeoutDuration, fb.Client.Timeout)
 }
 
 func TestTimeoutDuration_Dial(t *testing.T) {
 	fb := New("http://dialtimeouterr.or/")
 
-	timeoutDialer := (&net.Dialer{Timeout: time.Nanosecond}).Dial
-	fb.client.Transport.(*http.Transport).Dial = timeoutDialer
+	quickDialer := (&net.Dialer{Timeout: time.Nanosecond}).Dial
+	fb.Client.Transport.(*http.Transport).Dial = quickDialer
 
 	err := fb.Value("")
 	assert.NotNil(t, err)
 	assert.IsType(t, ErrTimeout{}, err, "%s", err)
-	assert.Equal(t, TimeoutDuration, fb.client.Timeout)
+	assert.Equal(t, TimeoutDuration, fb.Client.Timeout)
 }
 
 func TestShallow(t *testing.T) {

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -69,16 +69,15 @@ func TestChild(t *testing.T) {
 }
 
 func TestTimeoutDuration_Headers(t *testing.T) {
-	c := make(chan struct{})
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		<-c
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * TimeoutDuration)
 	}))
-	defer close(c)
 
 	fb := New(server.URL)
+
 	err := fb.Value("")
 	assert.NotNil(t, err)
-	assert.IsType(t, ErrTimeout{}, err)
+	assert.IsType(t, ErrTimeout{}, err, "%s", err)
 	assert.Equal(t, TimeoutDuration, fb.client.Timeout)
 }
 

--- a/push.go
+++ b/push.go
@@ -18,6 +18,6 @@ func (fb *Firebase) Push(v interface{}) (*Firebase, error) {
 	}
 	return &Firebase{
 		url:    fb.url + "/" + m["name"],
-		client: fb.client,
+		Client: fb.Client,
 	}, err
 }

--- a/push_test.go
+++ b/push_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zabawaba99/firetest"
 )
 
@@ -19,7 +20,7 @@ func TestPush(t *testing.T) {
 
 	fb := New(server.URL)
 	childRef, err := fb.Push(payload)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	path := strings.TrimPrefix(childRef.String(), server.URL+"/")
 	v := server.Get(path)

--- a/watch.go
+++ b/watch.go
@@ -69,7 +69,7 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 	req.Header.Add("Accept", "text/event-stream")
 
 	// do request
-	resp, err := fb.client.Do(req)
+	resp, err := fb.Client.Do(req)
 	if err != nil {
 		fb.setWatching(false)
 		return err


### PR DESCRIPTION
closes #20

Wrapping `http.Transport` in a custom struct and locking `ResponseHeaderTimeout` doesn't actually solve the race condition since `net/http` accesses `ResponseHeaderTimeout` directly.

This change removes the logic in `http.(*Transport).Dial` that was decrementing `ResponseHeaderTimeout` with the time it took to do `net.DialTimeout`. This means that where `firego.TimeoutDuration` used to be the total timeout duration for both dialing and receiving headers from Firebase, now `firego.TimeoutDuration` is the timeout duration for dialing and receiving headers separately.

So, if `firego.TimeoutDuration` is 1 second, then `firego` will allow 1 second for dialing, and 1 second to recieve headers.
