### PR TITLE
Retry request with new Location on 307 response

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -177,7 +177,16 @@ func (fb *Firebase) doRequest(method string, body []byte) ([]byte, error) {
 	default:
 		return nil, err
 	case nil:
-		// carry on
+		// check for 307 redirect
+		if resp.StatusCode == http.StatusTemporaryRedirect {
+			loc, err := resp.Location()
+			if err != nil {
+				return nil, err
+			}
+
+			fb.url = strings.Split(loc.String(), "/.json")[0]
+			return fb.doRequest(method, body)
+		}
 
 	case *_url.Error:
 		// `http.Client.Do` will return a `url.Error` that wraps a `net.Error`


### PR DESCRIPTION
- Nest API requires that all 307s are followed. The new location should
  become the new base URL for all further requests.
