### PR TITLE
Enable use of firego with provided http client connection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Steven Berlanga
+Copyright (c) 2015 Steven Berlanga, Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ import "github.com/zabawaba99/firego"
 Create a new firego reference
 
 ```go
-f := firego.New("https://my-firebase-app.firebaseIO.com")
+f := firego.New("https://my-firebase-app.firebaseIO.com", nil)
+```
+
+with existing http client
+
+```go
+f := firego.New("https://my-firebase-app.firebaseIO.com", client)
 ```
 
 ### Request Timeouts

--- a/auth_test.go
+++ b/auth_test.go
@@ -16,7 +16,7 @@ func TestAuth(t *testing.T) {
 	defer server.Close()
 
 	server.RequireAuth(true)
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 
 	fb.Auth(server.Secret)
 	var v interface{}
@@ -31,7 +31,7 @@ func TestUnauth(t *testing.T) {
 	defer server.Close()
 
 	server.RequireAuth(true)
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 
 	fb.params.Add("auth", server.Secret)
 	fb.Unauth()

--- a/firebase.go
+++ b/firebase.go
@@ -82,24 +82,26 @@ func redirectPreserveHeaders(req *http.Request, via []*http.Request) error {
 	return nil
 }
 
-// New creates a new Firebase reference
-func New(url string) *Firebase {
+// New creates a new Firebase reference,
+// if client is nil, http.DefaultClient is used
+func New(url string, client *http.Client) *Firebase {
 
-	var tr *http.Transport
-	tr = &http.Transport{
-		DisableKeepAlives: true, // https://code.google.com/p/go/issues/detail?id=3514
-		Dial: func(network, address string) (net.Conn, error) {
-			start := time.Now()
-			c, err := net.DialTimeout(network, address, TimeoutDuration)
-			tr.ResponseHeaderTimeout = TimeoutDuration - time.Since(start)
-			return c, err
-		},
-	}
+	if client == nil {
+		var tr *http.Transport
+		tr = &http.Transport{
+			DisableKeepAlives: true, // https://code.google.com/p/go/issues/detail?id=3514
+			Dial: func(network, address string) (net.Conn, error) {
+				start := time.Now()
+				c, err := net.DialTimeout(network, address, TimeoutDuration)
+				tr.ResponseHeaderTimeout = TimeoutDuration - time.Since(start)
+				return c, err
+			},
+		}
 
-	var client *http.Client
-	client = &http.Client{
-		Transport:     tr,
-		CheckRedirect: redirectPreserveHeaders,
+		client = &http.Client{
+			Transport:     tr,
+			CheckRedirect: redirectPreserveHeaders,
+		}
 	}
 
 	return &Firebase{

--- a/push_test.go
+++ b/push_test.go
@@ -17,7 +17,7 @@ func TestPush(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 	childRef, err := fb.Push(payload)
 	assert.NoError(t, err)
 

--- a/remove_test.go
+++ b/remove_test.go
@@ -15,7 +15,7 @@ func TestRemove(t *testing.T) {
 
 	server.Set("", true)
 
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 	err := fb.Remove()
 	assert.NoError(t, err)
 

--- a/set_test.go
+++ b/set_test.go
@@ -16,7 +16,7 @@ func TestSet(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 	err := fb.Set(payload)
 	assert.NoError(t, err)
 

--- a/update_test.go
+++ b/update_test.go
@@ -16,7 +16,7 @@ func TestUpdate(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 	err := fb.Update(payload)
 	assert.NoError(t, err)
 

--- a/value_test.go
+++ b/value_test.go
@@ -16,7 +16,7 @@ func TestValue(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 
 	server.Set("", response)
 

--- a/watch_test.go
+++ b/watch_test.go
@@ -21,7 +21,7 @@ func TestWatch(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 
 	notifications := make(chan Event)
 	err := fb.Watch(notifications)
@@ -67,7 +67,7 @@ func TestWatchRedirectPreservesHeader(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 	notifications := make(chan Event)
 
 	err := fb.Watch(notifications)
@@ -89,7 +89,7 @@ func TestWatchError(t *testing.T) {
 
 	var (
 		notifications = make(chan Event)
-		fb            = New(server.URL)
+		fb            = New(server.URL, nil)
 	)
 	defer server.Close()
 
@@ -113,7 +113,7 @@ func TestStopWatch(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	fb := New(server.URL)
+	fb := New(server.URL, nil)
 
 	notifications := make(chan Event)
 	go func() {


### PR DESCRIPTION
UPDATE following discussion:

This PR implements a breaking change adding a parameter to the New() constructor to pass an existing http client. The "old" behavior can be be achieved by passing "nil" as client. 
# 

I added a new constructor NewFromHttpClient() that takes a Firebase url and an existing
http client as parameters to create a Firebase connection for
use on e.g. Google App Engine.

Google App Engine has a custom way to obtain a http client.
Firego does not work on Google App Engine with the 
http.client that is created in *firego.New().
