### PR TITLE
Refactor watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea
+*.iml

--- a/watch.go
+++ b/watch.go
@@ -3,6 +3,8 @@ package firego
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -21,7 +23,23 @@ type Event struct {
 	// Path to the data that changed
 	Path string
 	// Data that changed
-	Data interface{}
+	Data    interface{}
+	payload string
+}
+
+func (e Event) Value(v interface{}) (path string, err error) {
+	var p struct {
+		Path string      `json:"path"`
+		Data interface{} `json:"data"`
+	}
+	p.Data = &v
+	err = json.Unmarshal([]byte(e.payload), &p)
+	if err != nil {
+		path = ""
+	} else {
+		path = p.Path
+	}
+	return
 }
 
 // StopWatching stops tears down all connections that are watching.
@@ -103,48 +121,54 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 			// 		event: put
 			// 		data: {"path":"/","data":{"foo":"bar"}}
 
-			var evt []byte
-			var dat []byte
-			isPrefix := true
-			var result []byte
-
-			// For possible results larger than 64 * 1024 bytes (MaxTokenSize)
-			// we need bufio#ReadLine()
-			// 1. step: scan for the 'event:' part. ReadLine() oes not return the \n
-			// so we have to add it to our result buffer.
-			evt, isPrefix, scanErr = scanner.ReadLine()
-			if scanErr != nil {
-				break scanning
-			}
-			result = append(result, evt...)
-			result = append(result, '\n')
-
-			// 2. step: scan for the 'data:' part. Firebase returns just one 'data:'
-			// part, but the value can be very large. If we exceed a certain length
-			// isPrefix will be true until all data is read.
-			for {
-				dat, isPrefix, scanErr = scanner.ReadLine()
-				if scanErr != nil {
-					break scanning
+			payload := make([]string, 2)
+			scanErr = func(payload []string) error {
+				lineCount := 0
+				for {
+					line, err := scanner.ReadString('\n')
+					if err != nil {
+						return err
+					}
+					line = strings.Trim(line, " \r\n")
+					if len(line) == 0 { // empty line
+						if lineCount == len(payload) {
+							return nil // everything OK
+						} else {
+							return errors.New("Bad formated body")
+						}
+					}
+					if lineCount < len(payload) {
+						payload[lineCount] = line
+						lineCount++
+					}
 				}
-				result = append(result, dat...)
-				if !isPrefix {
-					break
-				}
-			}
-			// Again we add the \n
-			result = append(result, '\n')
-			_, _, scanErr = scanner.ReadLine()
+			}(payload)
 			if scanErr != nil {
 				break scanning
 			}
 
-			txt := string(result)
-			parts := strings.Split(txt, "\n")
+			var eventType string
+			if strings.HasPrefix(payload[0], "event:") {
+				eventType = strings.TrimPrefix(payload[0], "event:")
+				eventType = strings.Trim(eventType, " \r\n")
+			} else {
+				scanErr = errors.New("First line does not start with event:")
+				break scanning
+			}
+
+			var eventData string
+			if strings.HasPrefix(payload[1], "data:") {
+				eventData = strings.TrimPrefix(payload[1], "data:")
+				eventData = strings.Trim(eventData, " \r\n")
+			} else {
+				scanErr = errors.New("Second line does not start with data:")
+				break scanning
+			}
 
 			// create a base event
 			event := Event{
-				Type: strings.Replace(parts[0], "event: ", "", 1),
+				Type:    eventType,
+				payload: eventData,
 			}
 
 			// should be reacting differently based off the type of event
@@ -153,7 +177,7 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 
 				// the extra data is in json format
 				var data map[string]interface{}
-				if err := json.Unmarshal([]byte(strings.Replace(parts[1], "data: ", "", 1)), &data); err != nil {
+				if err := json.Unmarshal([]byte(eventData), &data); err != nil {
 					scanErr = err
 					break scanning
 				}
@@ -161,7 +185,7 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 				// set the extra fields
 				event.Path = data["path"].(string)
 				event.Data = data["data"]
-
+				
 				// ship it
 				notifications <- event
 			case "keep-alive":
@@ -180,7 +204,8 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 
 				// TODO: handle
 			case "rules_debug":
-				log.Printf("Rules-Debug: %s\n", txt)
+				txt, _ := ioutil.ReadAll(resp.Body)
+				log.Printf("Rules-Debug: %s\n", string(txt))
 			}
 		}
 

--- a/watch.go
+++ b/watch.go
@@ -185,7 +185,7 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 				// set the extra fields
 				event.Path = data["path"].(string)
 				event.Data = data["data"]
-				
+
 				// ship it
 				notifications <- event
 			case "keep-alive":

--- a/watch.go
+++ b/watch.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"

--- a/watch.go
+++ b/watch.go
@@ -206,8 +206,7 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 
 				// TODO: handle
 			case "rules_debug":
-				txt, _ := ioutil.ReadAll(resp.Body)
-				log.Printf("Rules-Debug: %s\n", string(txt))
+				log.Printf("Rules-Debug: %s\n", eventData)
 			}
 		}
 


### PR DESCRIPTION
This patch can be used to address the issue #17 (Watch(Event) should be able to unmarshal to user-defined struct). This is what I did:
1. **Simplify** the extraction of the data from the body of the server's reply. I didn't like the idea of having to "glue" lines together and then split them right afterwards. I also wanted something **more robust** that checks if the lines are valid (e.g. a response of exactly 2 lines, the first must start with "event:" and the second line must start with "data:"). I used "scanner.ReadString" to read string of any length.
2. Keep a copy of the json from the second line ("data: <json>") in a private field (Event.payload)
3. Implement "func (e Event) Value(v interface{}) (path string, err error)" that can be user to **unmarshal user-defined struct from the event's payload**
4. Implement a test case for the new method (TestWatchValue).

The advantage of this method is that the API is compatible with the current version.
The drawback is that we have to keep 2 copies of the data; one in the generic form (map[string]interface{}) and another as the original json string.

I also have some additional remarks to the "firego" library:
- I don't think that the "watchMtx" mutex is needed. Indeed you access shared resources, but assigning and reading a boolean is already atomic.
- In the comment of the "Watch" you write "_Only one connection can be established at a time._" I understand that with the current implementation (with a shared ".isWatching") , this is required. But why did you choose this implementation? Is there no use case for several concurrent "watch"?

-- Jacques.
