### PR TITLE
making name field available after Push

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -49,6 +49,7 @@ type Firebase struct {
 	url    string
 	params _url.Values
 	client *http.Client
+	name   string
 
 	watchMtx     sync.Mutex
 	watching     bool
@@ -112,6 +113,7 @@ func (fb *Firebase) Push(v interface{}) (*Firebase, error) {
 	return &Firebase{
 		url:    fb.url + "/" + m["name"],
 		client: fb.client,
+		name:   m["name"],
 	}, err
 }
 


### PR DESCRIPTION
According to [the reference](https://firebase.google.com/docs/reference/rest/database/), Push request returns a response with "name" field. This field is useful in many cases when Push request is finished successfully.
