### PR TITLE
Allow any type for range query parameters, preserve numeric strings

### DIFF
--- a/query.go
+++ b/query.go
@@ -8,17 +8,17 @@ import (
 
 // StartAt creates a new Firebase reference with the
 // requested StartAt configuration. The value that is passed in
-// is automatically escape if it is a string value.
+// is automatically escaped if it is a string value.
 //
-//    StartAt(7)        // -> endAt=7
-//    StartAt("foo")    // -> endAt="foo"
-//    StartAt(`"foo"`)  // -> endAt="foo"
+//    StartAt(7)        // -> startAt=7
+//    StartAt("foo")    // -> startAt="foo"
+//    StartAt(`"foo"`)  // -> startAt="foo"
 //
 // Reference https://www.firebase.com/docs/rest/guide/retrieving-data.html#section-rest-filtering
-func (fb *Firebase) StartAt(value string) *Firebase {
+func (fb *Firebase) StartAt(value interface{}) *Firebase {
 	c := fb.copy()
 	if value != "" {
-		c.params.Set(startAtParam, escapeString(value))
+		c.params.Set(startAtParam, escapeParameter(value))
 	} else {
 		c.params.Del(startAtParam)
 	}
@@ -27,17 +27,17 @@ func (fb *Firebase) StartAt(value string) *Firebase {
 
 // EndAt creates a new Firebase reference with the
 // requested EndAt configuration. The value that is passed in
-// is automatically escape if it is a string value.
+// is automatically escaped if it is a string value.
 //
 //    EndAt(7)        // -> endAt=7
 //    EndAt("foo")    // -> endAt="foo"
 //    EndAt(`"foo"`)  // -> endAt="foo"
 //
 // Reference https://www.firebase.com/docs/rest/guide/retrieving-data.html#section-rest-filtering
-func (fb *Firebase) EndAt(value string) *Firebase {
+func (fb *Firebase) EndAt(value interface{}) *Firebase {
 	c := fb.copy()
 	if value != "" {
-		c.params.Set(endAtParam, escapeString(value))
+		c.params.Set(endAtParam, escapeParameter(value))
 	} else {
 		c.params.Del(endAtParam)
 	}
@@ -46,7 +46,7 @@ func (fb *Firebase) EndAt(value string) *Firebase {
 
 // OrderBy creates a new Firebase reference with the
 // requested OrderBy configuration. The value that is passed in
-// is automatically escape if it is a string value.
+// is automatically escaped.
 //
 //    OrderBy(7)       // -> endAt=7
 //    OrderBy("foo")   // -> endAt="foo"
@@ -56,7 +56,7 @@ func (fb *Firebase) EndAt(value string) *Firebase {
 func (fb *Firebase) OrderBy(value string) *Firebase {
 	c := fb.copy()
 	if value != "" {
-		c.params.Set(orderByParam, escapeString(value))
+		c.params.Set(orderByParam, fmt.Sprintf(`%q`, strings.Trim(value, `"`)))
 	} else {
 		c.params.Del(orderByParam)
 	}
@@ -66,24 +66,23 @@ func (fb *Firebase) OrderBy(value string) *Firebase {
 // EqualTo sends the query string equalTo so that one can find a single value
 //
 // Reference https://www.firebase.com/docs/rest/guide/retrieving-data.html#section-rest-filtering
-func (fb *Firebase) EqualTo(value string) *Firebase {
+func (fb *Firebase) EqualTo(value interface{}) *Firebase {
 	c := fb.copy()
 	if value != "" {
-		c.params.Set(equalToParam, escapeString(value))
+		c.params.Set(equalToParam, escapeParameter(value))
 	} else {
 		c.params.Del(equalToParam)
 	}
 	return c
 }
 
-func escapeString(s string) string {
-	_, errNotInt := strconv.ParseInt(s, 10, 64)
-	_, errNotBool := strconv.ParseBool(s)
-	if errNotInt == nil || errNotBool == nil {
-		// we shouldn't escape bools or ints
-		return s
+func escapeParameter(s interface{}) string {
+	switch s.(type) {
+	case string:
+		return fmt.Sprintf(`%q`, strings.Trim(s.(string), `"`))
+	default:
+		return fmt.Sprintf(`%v`, s)
 	}
-	return fmt.Sprintf(`%q`, strings.Trim(s, `"`))
 }
 
 // LimitToFirst creates a new Firebase reference with the

--- a/query.go
+++ b/query.go
@@ -56,7 +56,7 @@ func (fb *Firebase) EndAt(value interface{}) *Firebase {
 func (fb *Firebase) OrderBy(value string) *Firebase {
 	c := fb.copy()
 	if value != "" {
-		c.params.Set(orderByParam, fmt.Sprintf(`%q`, strings.Trim(value, `"`)))
+		c.params.Set(orderByParam, escapeParameter(value))
 	} else {
 		c.params.Del(orderByParam)
 	}

--- a/query.go
+++ b/query.go
@@ -48,9 +48,9 @@ func (fb *Firebase) EndAt(value interface{}) *Firebase {
 // requested OrderBy configuration. The value that is passed in
 // is automatically escaped.
 //
-//    OrderBy(7)       // -> endAt=7
-//    OrderBy("foo")   // -> endAt="foo"
-//    OrderBy(`"foo"`) // -> endAt="foo"
+//    OrderBy("foo")   // -> orderBy="foo"
+//    OrderBy(`"foo"`) // -> orderBy="foo"
+//    OrderBy("$key")  // -> orderBy="$key"
 //
 // Reference https://www.firebase.com/docs/rest/guide/retrieving-data.html#section-rest-filtering
 func (fb *Firebase) OrderBy(value string) *Firebase {

--- a/query_test.go
+++ b/query_test.go
@@ -98,7 +98,7 @@ func TestStartAt(t *testing.T) {
 	)
 	defer server.Close()
 
-	fb.StartAt("3").Value("")
+	fb.StartAt(3).Value("")
 	fb.StartAt("foo").Value("")
 	require.Len(t, server.receivedReqs, 2)
 
@@ -117,7 +117,7 @@ func TestEndAt(t *testing.T) {
 	)
 	defer server.Close()
 
-	fb.EndAt("4").Value("")
+	fb.EndAt(4).Value("")
 	fb.EndAt("theend").Value("")
 	require.Len(t, server.receivedReqs, 2)
 
@@ -159,25 +159,28 @@ func TestQueryMultipleParams(t *testing.T) {
 	)
 	defer server.Close()
 
-	fb.OrderBy("user_id").StartAt("7").Value("")
+	fb.OrderBy("user_id").StartAt(7).Value("")
 	require.Len(t, server.receivedReqs, 1)
 
 	req := server.receivedReqs[0]
 	assert.Equal(t, orderByParam+"=%22user_id%22&startAt=7", req.URL.Query().Encode())
 }
 
-func TestEscapeString(t *testing.T) {
+func TestEscapeParameter(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		value    string
+		value    interface{}
 		expected string
 	}{
 		{"foo", `"foo"`},
-		{"2", `2`},
-		{"false", `false`},
+		{2, `2`},
+		{"3", `"3"`},
+		{true, `true`},
+		{"false", `"false"`},
+		{3.14, `3.14`},
 	}
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expected, escapeString(testCase.value))
+		assert.Equal(t, testCase.expected, escapeParameter(testCase.value))
 	}
 }


### PR DESCRIPTION
This PR has a breaking change to how query parameters StartAt, EndAt and EqualTo work.

Previously these functions took a string as a parameter, tried to parse it into integer or boolean, and if none succeeded, escaped it with quotes.

This behavior is incorrect in my opinion, as:
- It's possible that a string contains a valid number, but still should be escaped;
- especially since Firebase has a strict precedence of types when performing range queries, e.g. `"true" != true` and `"10231232" != 10231232`, leaving the user of the library baffled why nothing is being returned*.
- Floating point numbers are numbers too.

Instead, I modified the functions to take an empty interface instead, and use a type switch to decide if it should be quoted or just printed to string without quotes. The `TestEscapeParameter` test shows all the expected conversions.

---

* _This is actually how I found this library, trying to find the answer to one such issue on the firebase-community Slack._ 😉 