### PR TITLE
Not panicking when calling StopWatching.

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -100,10 +100,7 @@ func (fb *Firebase) Watch(notifications chan Event) error {
 	}()
 
 	go func() {
-		defer func() {
-			close(notifications)
-			close(stop)
-		}()
+		defer close(notifications)
 
 		for event := range events {
 			if closedManually {


### PR DESCRIPTION
fixes #66. We do not need to close the stop channel since no one is listening to that notification and it will just get garabe collected