### PR TITLE
Change reference url

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -106,20 +106,12 @@ func (fb *Firebase) Unauth() {
 }
 
 // SetRef changes the current reference location whilst keeping the host url.
-func (fb *Firebase) SetRef(path string) {
+func (fb *Firebase) SetRef(path string) error {
 	parsedURL, err := _url.Parse(fb.url)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	if strings.Index(path, "/") == 0 {
-		path = path[1:] // Remove prefix '/' if exists
-	}
-	fb.url = parsedURL.Scheme + "://" + parsedURL.Host + "/" + path
-}
-
-// SetURL changes the url for a firebase reference.
-func (fb *Firebase) SetURL(url string) {
-	fb.url = sanitizeURL(url)
+	fb.url = parsedURL.Scheme + "://" + parsedURL.Host + "/" + strings.Trim(path, "/")
 }
 
 // Push creates a reference to an auto-generated child location.

--- a/firebase.go
+++ b/firebase.go
@@ -105,6 +105,20 @@ func (fb *Firebase) Unauth() {
 	fb.params.Del(authParam)
 }
 
+// SetRef changes the current reference location whilst keeping the host url.
+func (fb *Firebase) SetRef(path string) {
+	parsedURL, err := _url.Parse(fb.url)
+	if err != nil {
+		panic(err)
+	}
+	fb.url = parsedURL.Scheme + "://" + parsedURL.Host + "/" + path
+}
+
+// SetURL changes the url for a firebase reference.
+func (fb *Firebase) SetURL(url string) {
+	fb.url = sanitizeURL(url)
+}
+
 // Push creates a reference to an auto-generated child location.
 func (fb *Firebase) Push(v interface{}) (*Firebase, error) {
 	bytes, err := json.Marshal(v)

--- a/firebase.go
+++ b/firebase.go
@@ -111,6 +111,9 @@ func (fb *Firebase) SetRef(path string) {
 	if err != nil {
 		panic(err)
 	}
+	if strings.Index(path, "/") == 0 {
+		path = path[1:] // Remove prefix '/' if exists
+	}
 	fb.url = parsedURL.Scheme + "://" + parsedURL.Host + "/" + path
 }
 


### PR DESCRIPTION
Added two new functions.

- `SetRef(path string)`
- `SetUR(url string)`

**SetRef(path string)**
Edits the url for a firebase reference and changes the current path to a new path.

**SetURL(url string)**
Changes the complete URL of an existing firebase reference.

These functions can be useful in a number of ways with one being the fact that you no longer need to re-auth each time you change a firebase reference.