### PR TITLE
Allow any type for range query parameters, take 2

### DIFF
--- a/query.go
+++ b/query.go
@@ -8,13 +8,15 @@ import (
 
 // StartAt creates a new Firebase reference with the
 // requested StartAt configuration. The value that is passed in
-// is automatically escape if it is a string value.
+// is automatically escaped if it is a string value.
+// Numeric strings are automatically converted to numbers.
 //
-//    StartAt(7)        // -> endAt=7
-//    StartAt("foo")    // -> endAt="foo"
-//    StartAt(`"foo"`)  // -> endAt="foo"
+//    StartAt(7)        // -> startAt=7
+//    StartAt("7")      // -> startAt=7
+//    StartAt("foo")    // -> startAt="foo"
+//    StartAt(`"foo"`)  // -> startAt="foo"
 //
-// Reference https://www.firebase.com/docs/rest/guide/retrieving-data.html#section-rest-filtering
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#section-rest-filtering
 func (fb *Firebase) StartAt(value string) *Firebase {
 	c := fb.copy()
 	if value != "" {
@@ -27,13 +29,15 @@ func (fb *Firebase) StartAt(value string) *Firebase {
 
 // EndAt creates a new Firebase reference with the
 // requested EndAt configuration. The value that is passed in
-// is automatically escape if it is a string value.
+// is automatically escaped if it is a string value.
+// Numeric strings are automatically converted to numbers.
 //
 //    EndAt(7)        // -> endAt=7
+//    EndAt("7")      // -> endAt=7
 //    EndAt("foo")    // -> endAt="foo"
 //    EndAt(`"foo"`)  // -> endAt="foo"
 //
-// Reference https://www.firebase.com/docs/rest/guide/retrieving-data.html#section-rest-filtering
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#section-rest-filtering
 func (fb *Firebase) EndAt(value string) *Firebase {
 	c := fb.copy()
 	if value != "" {
@@ -48,11 +52,11 @@ func (fb *Firebase) EndAt(value string) *Firebase {
 // requested OrderBy configuration. The value that is passed in
 // is automatically escape if it is a string value.
 //
-//    OrderBy(7)       // -> endAt=7
-//    OrderBy("foo")   // -> endAt="foo"
-//    OrderBy(`"foo"`) // -> endAt="foo"
+//    OrderBy("foo")   // -> orderBy="foo"
+//    OrderBy(`"foo"`) // -> orderBy="foo"
+//    OrderBy("$key")  // -> orderBy="$key"
 //
-// Reference https://www.firebase.com/docs/rest/guide/retrieving-data.html#section-rest-filtering
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#orderby
 func (fb *Firebase) OrderBy(value string) *Firebase {
 	c := fb.copy()
 	if value != "" {
@@ -63,9 +67,17 @@ func (fb *Firebase) OrderBy(value string) *Firebase {
 	return c
 }
 
-// EqualTo sends the query string equalTo so that one can find a single value
+// EqualTo sends the query string equalTo so that one can find nodes with
+// exactly matching values. The value that is passed in is automatically escaped
+// if it is a string value.
+// Numeric strings are automatically converted to numbers.
 //
-// Reference https://www.firebase.com/docs/rest/guide/retrieving-data.html#section-rest-filtering
+//    EqualTo(7)        // -> equalTo=7
+//    EqualTo("7")      // -> equalTo=7
+//    EqualTo("foo")    // -> equalTo="foo"
+//    EqualTo(`"foo"`)  // -> equalTo="foo"
+//
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#section-rest-filtering
 func (fb *Firebase) EqualTo(value string) *Firebase {
 	c := fb.copy()
 	if value != "" {
@@ -98,7 +110,7 @@ func escapeParameter(s interface{}) string {
 // LimitToFirst creates a new Firebase reference with the
 // requested limitToFirst configuration.
 //
-// Reference https://www.firebase.com/docs/rest/api/#section-param-query
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#limit-queries
 func (fb *Firebase) LimitToFirst(value int64) *Firebase {
 	c := fb.copy()
 	if value > 0 {
@@ -112,7 +124,7 @@ func (fb *Firebase) LimitToFirst(value int64) *Firebase {
 // LimitToLast creates a new Firebase reference with the
 // requested limitToLast configuration.
 //
-// Reference https://www.firebase.com/docs/rest/api/#section-param-query
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#limit-queries
 func (fb *Firebase) LimitToLast(value int64) *Firebase {
 	c := fb.copy()
 	if value > 0 {
@@ -128,7 +140,7 @@ func (fb *Firebase) LimitToLast(value int64) *Firebase {
 // its value will be returned. If the data is a JSON object, the values
 // for each key will be truncated to true.
 //
-// Reference https://www.firebase.com/docs/rest/api/#section-param-shallow
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#shallow
 func (fb *Firebase) Shallow(v bool) {
 	if v {
 		fb.params.Set(shallowParam, "true")

--- a/query.go
+++ b/query.go
@@ -27,6 +27,27 @@ func (fb *Firebase) StartAt(value string) *Firebase {
 	return c
 }
 
+// StartAtValue creates a new Firebase reference with the
+// requested StartAt configuration. The value that is passed in
+// is automatically escaped if it is a string value.
+// Numeric strings are preserved as strings.
+//
+//    StartAtValue(7)        // -> startAt=7
+//    StartAtValue("7")      // -> startAt="7"
+//    StartAtValue("foo")    // -> startAt="foo"
+//    StartAtValue(`"foo"`)  // -> startAt="foo"
+//
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#section-rest-filtering
+func (fb *Firebase) StartAtValue(value interface{}) *Firebase {
+	c := fb.copy()
+	if value != "" {
+		c.params.Set(startAtParam, escapeParameter(value))
+	} else {
+		c.params.Del(startAtParam)
+	}
+	return c
+}
+
 // EndAt creates a new Firebase reference with the
 // requested EndAt configuration. The value that is passed in
 // is automatically escaped if it is a string value.
@@ -48,9 +69,30 @@ func (fb *Firebase) EndAt(value string) *Firebase {
 	return c
 }
 
+// EndAtValue creates a new Firebase reference with the
+// requested EndAt configuration. The value that is passed in
+// is automatically escaped if it is a string value.
+// Numeric strings are preserved as strings.
+//
+//    EndAtValue(7)        // -> endAt=7
+//    EndAtValue("7")      // -> endAt="7"
+//    EndAtValue("foo")    // -> endAt="foo"
+//    EndAtValue(`"foo"`)  // -> endAt="foo"
+//
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#section-rest-filtering
+func (fb *Firebase) EndAtValue(value interface{}) *Firebase {
+	c := fb.copy()
+	if value != "" {
+		c.params.Set(endAtParam, escapeParameter(value))
+	} else {
+		c.params.Del(endAtParam)
+	}
+	return c
+}
+
 // OrderBy creates a new Firebase reference with the
 // requested OrderBy configuration. The value that is passed in
-// is automatically escape if it is a string value.
+// is automatically escaped if it is a string value.
 //
 //    OrderBy("foo")   // -> orderBy="foo"
 //    OrderBy(`"foo"`) // -> orderBy="foo"
@@ -82,6 +124,27 @@ func (fb *Firebase) EqualTo(value string) *Firebase {
 	c := fb.copy()
 	if value != "" {
 		c.params.Set(equalToParam, escapeString(value))
+	} else {
+		c.params.Del(equalToParam)
+	}
+	return c
+}
+
+// EqualToValue sends the query string equalTo so that one can find nodes with
+// exactly matching values. The value that is passed in is automatically escaped
+// if it is a string value.
+// Numeric strings are preserved as strings.
+//
+//    EqualToValue(7)        // -> equalTo=7
+//    EqualToValue("7")      // -> equalTo="7"
+//    EqualToValue("foo")    // -> equalTo="foo"
+//    EqualToValue(`"foo"`)  // -> equalTo="foo"
+//
+// Reference https://firebase.google.com/docs/database/rest/retrieve-data#section-rest-filtering
+func (fb *Firebase) EqualToValue(value interface{}) *Firebase {
+	c := fb.copy()
+	if value != "" {
+		c.params.Set(equalToParam, escapeParameter(value))
 	} else {
 		c.params.Del(equalToParam)
 	}

--- a/query.go
+++ b/query.go
@@ -86,6 +86,15 @@ func escapeString(s string) string {
 	return fmt.Sprintf(`%q`, strings.Trim(s, `"`))
 }
 
+func escapeParameter(s interface{}) string {
+	switch s.(type) {
+	case string:
+		return fmt.Sprintf(`%q`, strings.Trim(s.(string), `"`))
+	default:
+		return fmt.Sprintf(`%v`, s)
+	}
+}
+
 // LimitToFirst creates a new Firebase reference with the
 // requested limitToFirst configuration.
 //

--- a/query_test.go
+++ b/query_test.go
@@ -60,6 +60,34 @@ func TestEqualTo(t *testing.T) {
 	assert.Equal(t, equalToParam+"=%22user_id%22", req.URL.Query().Encode())
 }
 
+func TestEqualToValue(t *testing.T) {
+	t.Parallel()
+	var (
+		server = newTestServer("")
+		fb     = New(server.URL, nil)
+	)
+	defer server.Close()
+
+	fb.EqualToValue(2).Value("")
+	fb.EqualToValue("2").Value("")
+	fb.EqualToValue(2.14).Value("")
+	fb.EqualToValue("bar").Value("")
+	require.Len(t, server.receivedReqs, 4)
+
+	req := server.receivedReqs[0]
+	assert.Equal(t, equalToParam+"=2", req.URL.Query().Encode())
+
+	req = server.receivedReqs[1]
+	assert.Equal(t, equalToParam+"=%222%22", req.URL.Query().Encode())
+
+	req = server.receivedReqs[2]
+	assert.Equal(t, equalToParam+"=2.14", req.URL.Query().Encode())
+
+	req = server.receivedReqs[3]
+	assert.Equal(t, equalToParam+"=%22bar%22", req.URL.Query().Encode())
+
+}
+
 func TestLimitToFirst(t *testing.T) {
 	t.Parallel()
 	var (
@@ -109,6 +137,33 @@ func TestStartAt(t *testing.T) {
 	assert.Equal(t, startAtParam+"=%22foo%22", req.URL.Query().Encode())
 }
 
+func TestStartAtValue(t *testing.T) {
+	t.Parallel()
+	var (
+		server = newTestServer("")
+		fb     = New(server.URL, nil)
+	)
+	defer server.Close()
+
+	fb.StartAtValue(3).Value("")
+	fb.StartAtValue("3").Value("")
+	fb.StartAtValue(3.14).Value("")
+	fb.StartAtValue("foo").Value("")
+	require.Len(t, server.receivedReqs, 4)
+
+	req := server.receivedReqs[0]
+	assert.Equal(t, startAtParam+"=3", req.URL.Query().Encode())
+
+	req = server.receivedReqs[1]
+	assert.Equal(t, startAtParam+"=%223%22", req.URL.Query().Encode())
+
+	req = server.receivedReqs[2]
+	assert.Equal(t, startAtParam+"=3.14", req.URL.Query().Encode())
+
+	req = server.receivedReqs[3]
+	assert.Equal(t, startAtParam+"=%22foo%22", req.URL.Query().Encode())
+}
+
 func TestEndAt(t *testing.T) {
 	t.Parallel()
 	var (
@@ -125,6 +180,33 @@ func TestEndAt(t *testing.T) {
 	assert.Equal(t, endAtParam+"=4", req.URL.Query().Encode())
 
 	req = server.receivedReqs[1]
+	assert.Equal(t, endAtParam+"=%22theend%22", req.URL.Query().Encode())
+}
+
+func TestEndAtValue(t *testing.T) {
+	t.Parallel()
+	var (
+		server = newTestServer("")
+		fb     = New(server.URL, nil)
+	)
+	defer server.Close()
+
+	fb.EndAtValue(4).Value("")
+	fb.EndAtValue(3.14).Value("")
+	fb.EndAtValue("4").Value("")
+	fb.EndAtValue("theend").Value("")
+	require.Len(t, server.receivedReqs, 4)
+
+	req := server.receivedReqs[0]
+	assert.Equal(t, endAtParam+"=4", req.URL.Query().Encode())
+
+	req = server.receivedReqs[1]
+	assert.Equal(t, endAtParam+"=3.14", req.URL.Query().Encode())
+
+	req = server.receivedReqs[2]
+	assert.Equal(t, endAtParam+"=%224%22", req.URL.Query().Encode())
+
+	req = server.receivedReqs[3]
 	assert.Equal(t, endAtParam+"=%22theend%22", req.URL.Query().Encode())
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -181,3 +181,22 @@ func TestEscapeString(t *testing.T) {
 		assert.Equal(t, testCase.expected, escapeString(testCase.value))
 	}
 }
+
+func TestEscapeParameter(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    interface{}
+		expected string
+	}{
+		{"foo", `"foo"`},
+		{2, `2`},
+		{"3", `"3"`},
+		{true, `true`},
+		{"false", `"false"`},
+		{3.14, `3.14`},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expected, escapeParameter(testCase.value))
+	}
+}


### PR DESCRIPTION
This PR is a reboot of #65, but instead of replacing the current functionality, new functions are added: StartAtValue, EndAtValue and EqualToValue. Everything else is the same as back then.