### PR TITLE
Add Exist method

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -156,6 +156,21 @@ func (fb *Firebase) Value(v interface{}) error {
 	return json.Unmarshal(bytes, v)
 }
 
+// Exists checks if a value of the Firebase reference exists. It returns (true, nil), if the value exists. If the value
+// doesn't exists it return false, nil. Also, in case of error during the call it returns the error, therefore the
+// boolean value should be ignored.
+func (fb *Firebase) Exists() (bool, error) {
+	bytes, err := fb.doRequest("GET", nil)
+
+	if err != nil {
+		return false, err
+	}
+	
+	// if the searched reference doesn't exists, bytes contains an empty json, the double quotes are also part of
+	// the response "{}" and a new line character.
+	return len(bytes) > 5, nil
+}
+
 // String returns the string representation of the
 // Firebase reference.
 func (fb *Firebase) String() string {

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -167,6 +167,46 @@ func TestUpdate(t *testing.T) {
 	assert.Equal(t, payload, v)
 }
 
+func TestExists(t *testing.T) {
+	t.Parallel()
+	var (
+		response = map[string]interface{}{"foo": "bar"}
+		server   = firetest.New()
+		v        = map[string]interface{}{}
+	)
+	server.Start()
+	defer server.Close()
+
+	fb := New(server.URL, nil)
+	server.Set("", response)
+
+	fb.Value(&v)
+
+	exists, err := fb.Exists()
+	assert.NoError(t, err)
+	assert.Equal(t, true, exists)
+}
+
+func TestNotExists(t *testing.T) {
+	t.Parallel()
+	var (
+		response = "{}"
+		server   = firetest.New()
+		v        = map[string]interface{}{}
+	)
+	server.Start()
+	defer server.Close()
+
+	fb := New(server.URL, nil)
+	server.Set("", response)
+
+	fb.Value(&v)
+
+	exists, err := fb.Exists()
+	assert.NoError(t, err)
+	assert.Equal(t, false, exists)
+}
+
 func TestValue(t *testing.T) {
 	t.Parallel()
 	var (


### PR DESCRIPTION
The implementation avoids to unmarshall the content of the response. It assume that an empty response, which is what firebase returns when the node does not exists, is less than 5 bytes [34 123 125 34 10] "{}".