### PR TITLE
Avoid UnMarshalling when calling Exists function

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -118,12 +118,15 @@ func (fb *Firebase) Ref(path string) (*Firebase, error) {
 
 // Exists returns a boolean indicating if a value exist at the current reference
 func (fb *Firebase) Exists() (bool, error) {
-	var data interface{}
-	err := fb.Value(&data)
+	bytes, err := fb.doRequest("GET", nil)
+
 	if err != nil {
 		return false, err
 	}
-	return data != nil, nil
+
+	// If the searched reference doesn't exists, bytes contains an empty json "{}" where the double quotes are also
+	// and a new line character are also part of the response.
+	return len(bytes) > 5, nil
 }
 
 // SetURL changes the url for a firebase reference.

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -106,9 +106,15 @@ func TestExists(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, b)
 
+	// Test empty response
+	fb.Set("{}")
+	b, err = fb.Exists()
+	require.NoError(t, err)
+	assert.False(t, b)
+
 	//Test Exists on an non-empty ref
 	payload := map[string]interface{}{"foo": "bar"}
-	fb.Push(payload)
+	fb.Set(payload)
 	b, err = fb.Exists()
 	require.NoError(t, err)
 	assert.True(t, b)


### PR DESCRIPTION
The implementation avoids to unmarshall the content of the response. It assume that an empty response, which is what firebase returns when the node does not exists, is less than 5 bytes [34 123 125 34 10] "{}".